### PR TITLE
Add support for geo URI

### DIFF
--- a/src/utils/handleCoordsOrUrl.ts
+++ b/src/utils/handleCoordsOrUrl.ts
@@ -3,6 +3,8 @@ export default function handleCoordsOrUrl(str: any) {
     const lat = str.split("@")[1].split(",")[0];
     const lng = str.split("@")[1].split(",")[1].split(",")[0];
     return [lat, lng];
+  } else if (str.startsWith("geo://")) {
+    return str.slice(6).split(",");
   } else {
     return str
       .replaceAll("\u00B0", "")


### PR DESCRIPTION
I use geo:// URIs in my notes to create a clickable link I can open with OSMAnd on my phone.

This simple patch should provide support for geo://LAT,LNG.

I installed the development tools and successfully tested the result:

![image](https://github.com/Aethelflaed/logseq-osmmaps-plugin/assets/450928/4fef0f2c-1dad-42be-b527-4cc480eabf68)
